### PR TITLE
Allow perform(decoding:) to output a non-Optional type if successful

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Generate coverage report
-      run: xcodebuild -scheme Requests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=13.3' -enableCodeCoverage YES build test
+      run: xcodebuild -scheme Requests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=13.4.1' -enableCodeCoverage YES build test
     - name: Codecov
       uses: codecov/codecov-action@v1.0.5
       with:

--- a/Sources/Requests/Request.swift
+++ b/Sources/Requests/Request.swift
@@ -155,7 +155,7 @@ open class Request: AbstractRequest {
   ///   - error: The task error.
   open func perform<T: Decodable>(decoding object: T.Type,
                                   _ completionHandler: @escaping (
-    _ result: Result<(T?, URLResponse?), Error>) throws -> Void) {
+    _ result: Result<(T, URLResponse?), Error>) throws -> Void) {
 
     perform { result in
       switch result {
@@ -167,8 +167,7 @@ open class Request: AbstractRequest {
           return
         }
 
-        let object = try JSONDecoder().decode(T.self, from: data)
-        try completionHandler(.success((object, response.urlResponse)))
+        try completionHandler(.success((try JSONDecoder().decode(T.self, from: data), response.urlResponse)))
       case .failure(let error):
         try completionHandler(.failure(error))
       }

--- a/Tests/RequestsTests/RequestTests.swift
+++ b/Tests/RequestsTests/RequestTests.swift
@@ -100,7 +100,7 @@ final class RequestTests: XCTestCase {
       .perform(decoding: User.self) { result in
 
         if let response = try? result.get(),
-          response.0?.username == "test" {
+          response.0.username == "test" {
 
           decodingExpectation.fulfill()
         }


### PR DESCRIPTION
Request.perform(decoding:) currently outputs an Optional type even if the decoding is successful. This PR will change this behaviour by making it non-Optional.